### PR TITLE
conversion to fileupload2

### DIFF
--- a/assembly/src/main/assembly/min-lib.xml
+++ b/assembly/src/main/assembly/min-lib.xml
@@ -39,7 +39,7 @@
         <include>org.apache.commons:commons-text</include>
         <include>org.apache.logging.log4j:log4j-api</include>
         <include>ognl:ognl</include>
-        <include>commons-fileupload:commons-fileupload</include>
+        <include>org.apache.commons:commons-fileupload2-jakarta</include>
         <include>org.apache.commons:commons-io</include>
       </includes>
     </dependencySet>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,7 +91,6 @@
             </plugin>
         </plugins>
     </build>
-
     <profiles>
         <profile>
             <id>build-maven</id>
@@ -172,6 +171,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                     </plugin>
+
                 </plugins>
             </build>
         </profile>
@@ -214,14 +214,14 @@
 
         <!-- File upload -->
         <dependency>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-fileupload2-jakarta</artifactId>
+            <version>2.0.0-M1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
+++ b/core/src/main/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequest.java
@@ -18,12 +18,10 @@
  */
 package org.apache.struts2.dispatcher.multipart;
 
-import org.apache.commons.fileupload.FileItemIterator;
-import org.apache.commons.fileupload.FileItemStream;
-import org.apache.commons.fileupload.FileUploadBase;
-import org.apache.commons.fileupload.FileUploadBase.FileSizeLimitExceededException;
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.fileupload.util.Streams;
+import org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload;
+import org.apache.commons.fileupload2.core.FileUploadSizeException;
+import org.apache.commons.fileupload2.core.FileItemInputIterator;
+import org.apache.commons.fileupload2.core.FileItemInput;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts2.dispatcher.LocalizedMessage;
@@ -210,18 +208,16 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
      * @throws Exception
      */
     protected void processUpload(HttpServletRequest request, String saveDir) throws Exception {
-    	
-    	//TODO:  commons-upload upgrade
 
         // Sanity check that the request is a multi-part/form-data request.
-        /*if (ServletFileUpload.isMultipartContent(request)) {
+        if (JakartaServletFileUpload.isMultipartContent(request)) {
 
             // Sanity check on request size.
             boolean requestSizePermitted = isRequestSizePermitted(request);
 
             // Interface with Commons FileUpload API
             // Using the Streaming API
-            ServletFileUpload servletFileUpload = new ServletFileUpload();
+            JakartaServletFileUpload servletFileUpload = new JakartaServletFileUpload();
             if (maxSize != null) {
                 servletFileUpload.setSizeMax(maxSize);
             }
@@ -231,12 +227,12 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
             if (maxFileSize != null) {
                 servletFileUpload.setFileSizeMax(maxFileSize);
             }
-            FileItemIterator i = servletFileUpload.getItemIterator(request);
+            FileItemInputIterator i = servletFileUpload.getItemIterator(request);
 
             // Iterate the file items
             while (i.hasNext()) {
                 try {
-                    FileItemStream itemStream = i.next();
+                    FileItemInput itemStream = i.next();
 
                     // If the file item stream is a form field, delegate to the
                     // field item stream handler
@@ -263,7 +259,7 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
                     LOG.warn("Error occurred during process upload", e);
                 }
             }
-        }*/
+        }
     }
 
     /**
@@ -299,7 +295,7 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
     protected void addFileSkippedError(String fileName, HttpServletRequest request) {
         String exceptionMessage = "Skipped file " + fileName + "; request size limit exceeded.";
         long allowedMaxSize = maxSize != null ? maxSize : -1;
-        FileSizeLimitExceededException exception = new FileUploadBase.FileSizeLimitExceededException(exceptionMessage, getRequestSize(request), allowedMaxSize);
+        FileUploadSizeException exception = new FileUploadSizeException(exceptionMessage, getRequestSize(request), allowedMaxSize);
         LocalizedMessage message = buildErrorMessage(exception, new Object[]{fileName, getRequestSize(request), allowedMaxSize});
         if (!errors.contains(message)) {
             errors.add(message);
@@ -311,11 +307,12 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
      *
      * @param itemStream file item stream
      */
-    protected void processFileItemStreamAsFormField(FileItemStream itemStream) {
+    protected void processFileItemStreamAsFormField(FileItemInput itemStream) {
         String fieldName = itemStream.getFieldName();
         try {
             List<String> values;
-            String fieldValue = Streams.asString(itemStream.openStream());
+
+            String fieldValue = itemStream.getInputStream().toString();
             if (!parameters.containsKey(fieldName)) {
                 values = new ArrayList<>();
                 parameters.put(fieldName, values);
@@ -334,9 +331,9 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
      * @param itemStream file item stream
      * @param location location
      */
-    protected void processFileItemStreamAsFileField(FileItemStream itemStream, String location) {
+    protected void processFileItemStreamAsFileField(FileItemInput itemStream, String location) {
         // Skip file uploads that don't have a file name - meaning that no file was selected.
-        if (itemStream.getName() == null || itemStream.getName().trim().length() < 1) {
+        if (itemStream.getName() == null || itemStream.getName().trim().isEmpty()) {
             LOG.debug("No file has been uploaded for the field: {}", itemStream.getFieldName());
             return;
         }
@@ -398,9 +395,9 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
      * @return true if stream was successfully
      * @throws IOException in case of IO errors
      */
-    protected boolean streamFileToDisk(FileItemStream itemStream, File file) throws IOException {
+    protected boolean streamFileToDisk(FileItemInput itemStream, File file) throws IOException {
         boolean result;
-        try (InputStream input = itemStream.openStream();
+        try (InputStream input = itemStream.getInputStream();
                 OutputStream output = new BufferedOutputStream(Files.newOutputStream(file.toPath()), bufferSize)) {
             byte[] buffer = new byte[bufferSize];
             LOG.debug("Streaming file using buffer size {}.", bufferSize);
@@ -420,7 +417,7 @@ public class JakartaStreamMultiPartRequest extends AbstractMultiPartRequest {
      * @param itemStream file item stream
      * @param file the file
      */
-    protected void createFileInfoFromItemStream(FileItemStream itemStream, File file) {
+    protected void createFileInfoFromItemStream(FileItemInput itemStream, File file) {
         // gather attributes from file upload stream.
         String fileName = itemStream.getName();
         String fieldName = itemStream.getFieldName();

--- a/core/src/main/resources/org/apache/struts2/struts-messages.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages.properties
@@ -31,10 +31,10 @@ struts.messages.error.content.type.not.allowed=Content-Type not allowed: {0} "{1
 struts.messages.error.file.extension.not.allowed=File extension not allowed: {0} "{1}" "{2}" {3}
 
 # dedicated messages used to handle various problems with file upload - check {@link JakartaMultiPartRequest#parse(HttpServletRequest, String)}
-struts.messages.upload.error.SizeLimitExceededException=Request exceeded allowed size limit! Max size allowed is: {0} but request was: {1}!
-struts.messages.upload.error.FileCountLimitExceededException=Request exceeded allowed number of files! Max allowed files number is: {0}!
-struts.messages.upload.error.FileSizeLimitExceededException=File in request exceeded allowed file size limit! Max file size allowed is: {1} but file {0} was: {2}!
-struts.messages.upload.error.IOException=Error uploading: {0}!
+struts.messages.upload.error.FileUploadSizeException=Request exceeded allowed size limit! Max size allowed is: {0}!
+struts.messages.upload.error.FileUploadFileCountLimitException=Request exceeded allowed number of files! Max allowed files number is: {0}!
+struts.messages.upload.error.FileUploadByteCountLimitException=File in request exceeded allowed file size limit! Max file size allowed is: {1}!
+struts.messages.upload.error.FileUploadException=Error uploading: {0}!
 
 devmode.notification=Developer Notification (set struts.devMode to false to disable this message):\n{0}
 

--- a/core/src/main/resources/org/apache/struts2/struts-messages_da.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_da.properties
@@ -29,7 +29,7 @@ struts.messages.error.file.too.large=Filen er for stor: {0} "{1}" {2}
 struts.messages.error.content.type.not.allowed=Content-Type er ikke tilladt: {0} "{1}" {2}
 
 # dedicated messages used to handle various problems with file upload - check {@link JakartaMultiPartRequest#parse(HttpServletRequest, String)}
-struts.messages.upload.error.SizeLimitExceededException=Request overskredet tilladte st\u00F8rrelse gr\u00E6nse! Max tilladte st\u00F8rrelse er: {0}, men anmodning var: {1}!
-struts.messages.upload.error.IOException=Fejl ved upload: {0}!
+struts.messages.upload.error.FileUploadSizeException=Request overskredet tilladte st\u00F8rrelse gr\u00E6nse! Max tilladte st\u00F8rrelse er: {0}!
+struts.messages.upload.error.FileUploadException=Fejl ved upload: {0}!
 
 devmode.notification=Note til udvikler (ret struts.devMode til 'false' for at deaktivere denne meddelse):\n{0}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_de.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_de.properties
@@ -30,8 +30,8 @@ struts.messages.error.content.type.not.allowed=Content-Type nicht erlaubt: {0} "
 struts.messages.error.file.extension.not.allowed=File extension nicht erlaubt: {0} "{1}" "{2}" {3}
 
 # dedicated messages used to handle various problems with file upload - check {@link JakartaMultiPartRequest#parse(HttpServletRequest, String)}
-struts.messages.upload.error.SizeLimitExceededException=Der Request \u00FCbertraf die maximal erlaubte Gr\u00F6\u00DFe und wurde daher abgelehnt. Die maximal zul\u00E4ssige Gr\u00F6\u00DFe ist {0}, die Gr\u00F6\u00DFe der Anfrage betrug aber {1}!
+struts.messages.upload.error.FileUploadSizeException=Der Request \u00FCbertraf die maximal erlaubte Gr\u00F6\u00DFe und wurde daher abgelehnt. Die maximal zul\u00E4ssige Gr\u00F6\u00DFe ist {0}!
 
-struts.messages.upload.error.IOException=Fehler beim Upload: {0}!
+struts.messages.upload.error.FileUploadException=Fehler beim Upload: {0}!
 
 devmode.notification=Entwickler Hinweis (Setzen Sie struts.devMode auf false um diese Nachricht zu deaktivieren):\n{0}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_en.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_en.properties
@@ -34,8 +34,8 @@ struts.messages.error.content.type.not.allowed=Content-Type not allowed: {0} "{1
 struts.messages.error.file.extension.not.allowed=File extension not allowed: {0} "{1}" "{2}" {3}
 
 # dedicated messages used to handle various problems with file upload - check {@link JakartaMultiPartRequest#parse(HttpServletRequest, String)}
-struts.messages.upload.error.SizeLimitExceededException=Request exceeded allowed size limit! Max size allowed is: {0} but request was: {1}!
-struts.messages.upload.error.IOException=Error uploading: {0}!
+struts.messages.upload.error.FileUploadSizeException=Request exceeded allowed size limit! Max size allowed is: {0}!
+struts.messages.upload.error.FileUploadException=Error uploading: {0}!
 
 devmode.notification=Developer Notification (set struts.devMode to false to disable this message):\n{0}
 

--- a/core/src/main/resources/org/apache/struts2/struts-messages_pl.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_pl.properties
@@ -30,7 +30,7 @@ struts.messages.error.content.type.not.allowed=Niedozwolony Content-Type: {0} "{
 struts.messages.error.file.extension.not.allowed=Niedozwolony File extension: {0} "{1}" "{2}" {3}
 
 # dedicated messages used to handle various problems with file upload - check {@link JakartaMultiPartRequest#parse(HttpServletRequest, String)}
-struts.messages.upload.error.SizeLimitExceededException=Zapytanie przekroczy\u0142o dozwolony limit rozmiaru! Maksymalny rozmiar to: {0} ale \u017C\u0105danie mia\u0142o: {1}!
-struts.messages.upload.error.IOException=B\u0142\u0105d podczas wysy\u0142ania pliku: {0}!
+struts.messages.upload.error.FileUploadSizeException=Zapytanie przekroczy\u0142o dozwolony limit rozmiaru! Maksymalny rozmiar to: {0}!
+struts.messages.upload.error.FileUploadException=B\u0142\u0105d podczas wysy\u0142ania pliku: {0}!
 
 devmode.notification=Powiadmienie Developera (ustaw struts.devMode na false by wy\u0142\u0105czy\u0107 t\u0119 wiadomo\u015B\u0107):\n{0}

--- a/core/src/main/resources/org/apache/struts2/struts-messages_pt.properties
+++ b/core/src/main/resources/org/apache/struts2/struts-messages_pt.properties
@@ -29,7 +29,7 @@ struts.messages.error.file.too.large=Arquivo muito grande: {0} "{1}" {2}
 struts.messages.error.content.type.not.allowed=Content-Type n\u00E3o permitido: {0} "{1}" {2}
 
 # dedicated messages used to handle various problems with file upload - check {@link JakartaMultiPartRequest#parse(HttpServletRequest, String)}
-struts.messages.upload.error.SizeLimitExceededException=Pedido excedeu o limite de tamanho permitido! Tamanho m\u00E1ximo permitido \u00E9: {0} mas foi pedido: {1}!
-struts.messages.upload.error.IOException=Erro de uploading: {0}!
+struts.messages.upload.error.FileUploadSizeException=Pedido excedeu o limite de tamanho permitido! Tamanho m\u00E1ximo permitido \u00E9: {0}!
+struts.messages.upload.error.FileUploadException=Erro de uploading: {0}!
 
 devmode.notification=Notifica\u00E7\u00E3o para o Desenvolvedor (altere o param\u00EAtro struts.devMode para false para desabilitar esta mensagem):\n{0}

--- a/core/src/test/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequestTest.java
+++ b/core/src/test/java/org/apache/struts2/dispatcher/multipart/JakartaStreamMultiPartRequestTest.java
@@ -27,14 +27,12 @@ import java.nio.file.Paths;
 import org.apache.struts2.dispatcher.LocalizedMessage;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.mock.web.DelegatingServletInputStream;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-@Ignore
 public class JakartaStreamMultiPartRequestTest {
 
     private JakartaStreamMultiPartRequest multiPart;
@@ -68,6 +66,6 @@ public class JakartaStreamMultiPartRequestTest {
         multiPart.setMaxSize("4");
         multiPart.parse(request, tempDir.toString());
         LocalizedMessage next = multiPart.getErrors().iterator().next();
-        Assert.assertEquals(next.getTextKey(), "struts.messages.upload.error.SizeLimitExceededException");
+        Assert.assertEquals(next.getTextKey(), "struts.messages.upload.error.FileUploadSizeException");
     }
 }

--- a/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
+++ b/core/src/test/java/org/apache/struts2/interceptor/FileUploadInterceptorTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload;
 import org.apache.struts2.ServletActionContext;
 import org.apache.struts2.StrutsInternalTestCase;
 import org.apache.struts2.TestAction;
@@ -53,7 +54,7 @@ import jakarta.servlet.http.HttpServletRequest;
 /**
  * Test case for FileUploadInterceptor.
  */
-@Ignore
+
 public class FileUploadInterceptorTest extends StrutsInternalTestCase {
 
     public static final UploadedFile EMPTY_FILE = new UploadedFile() {
@@ -342,8 +343,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         content.append(endline);
         req.setContent(content.toString().getBytes());
 
-        fail("TODO");
-        //assertTrue(ServletFileUpload.isMultipartContent(req));
+        assertTrue(JakartaServletFileUpload.isMultipartContent(req));
 
         MyFileupAction action = new MyFileupAction();
         container.inject(action);
@@ -396,8 +396,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         content.append(endline);
         req.setContent(content.toString().getBytes());
 
-        fail("TODO");
-        //assertTrue(ServletFileUpload.isMultipartContent(req));
+        assertTrue(JakartaServletFileUpload.isMultipartContent(req));
 
         MyFileupAction action = new MyFileupAction();
         container.inject(action);
@@ -453,7 +452,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         assertEquals(1, errors.size());
         String msg = errors.iterator().next();
         assertEquals(
-                "File in request exceeded allowed file size limit! Max file size allowed is: 10 but file deleteme.txt was: 34!",
+                "File in request exceeded allowed file size limit! Max file size allowed is: 10!",
                 msg);
     }
 
@@ -555,6 +554,7 @@ public class FileUploadInterceptorTest extends StrutsInternalTestCase {
         sb.append(name);
         sb.append("\"; filename=\"");
         sb.append(filename);
+        sb.append("\"");
         sb.append(endline);
         sb.append("Content-Type: ");
         sb.append(contentType);

--- a/pom.xml
+++ b/pom.xml
@@ -836,9 +836,9 @@
                 <version>4.4</version>
             </dependency>
             <dependency>
-                <groupId>commons-fileupload</groupId>
-                <artifactId>commons-fileupload</artifactId>
-                <version>1.5</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-fileupload2-jakarta</artifactId>
+                <version>2.0.0-M1</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
converts fileupload dependency to new fileupload2-jakarta, and gets the two unit test related to file upload working

had to change error messages as fileupload no longer correctly reports the actual size of an file if its too big.

setting size threshold to 1 as using 0 or -1 no longer works

